### PR TITLE
Fix: 计划修复反向 dijkstra 算法的错误

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -755,10 +755,10 @@ int NinjaMain::ToolOrigin(const Options* options, int argc, char* argv[]) {
     return 1;
   }
 
-  OriginUtil origin_util(nodes, &state_, &disk_interface_);
+  OriginUtil origin_util(nodes);
 
   // for all the input argc target
-  origin_util.GetAllImpactNode(nodes);
+  origin_util.GetAllImpactNode();
   return 0;
 }
 

--- a/src/origin_util.cc
+++ b/src/origin_util.cc
@@ -2,9 +2,9 @@
 #include "graphviz.h"
 
 int OriginUtil::GetAllImpactNode() {
-  //ReverseDijkstra();
-  //PrintJSON();
   GetAllDirectNodes();
+  ReverseDijkstra();
+  PrintJSON();
 
   return 0;
 }
@@ -40,27 +40,27 @@ void OriginUtil::ReverseDijkstra() {
   for (auto node : input_target_) {
     q.push(node);
     reverse_djk_m.insert({ node, 1 });
+    ready_nodes_.insert(node);
   }
 
   while (!q.empty()) {
     Node* node = q.front();
     q.pop();
-    auto node_it = reverse_djk_m.find(node);
-    size_t dist = node_it->second;
 
     vector<Node*> output_nodes;
     GetOutputNodeByNode(node, &output_nodes);
     // 获取当前节点所有输出后，更新 map 中的距离
     for (auto node : output_nodes) {
-      auto iter = reverse_djk_m.find(node);
-      if (iter != reverse_djk_m.end() && iter->second < dist + 1) {
-        iter->second = dist + 1;
+      // 如果 target 节点并不是所有 source 都 ready 了，那就跳过
+      if (!AllSourcesReady(node)) {
+        continue;
       }
 
-      else if (iter == reverse_djk_m.end()) {
-        // 说明可以入 queue，因为 map 还没有记录过，说明是新节点
+      if (ready_nodes_.find(node) == ready_nodes_.end()) {
         q.push(node);
+        size_t dist = GetMaxDistanceByNode(node);
         reverse_djk_m.insert({ node, dist + 1 });
+        ready_nodes_.insert(node);
       }
     }
   }

--- a/src/origin_util.cc
+++ b/src/origin_util.cc
@@ -1,10 +1,37 @@
 #include "origin_util.h"
 #include "graphviz.h"
 
-int OriginUtil::GetAllImpactNode(vector<Node*> inputs) {
-  ReverseDijkstra();
-  PrintJSON();
+int OriginUtil::GetAllImpactNode() {
+  //ReverseDijkstra();
+  //PrintJSON();
+  GetAllDirectNodes();
+
   return 0;
+}
+
+/**
+ * @brief 获取所有直接影响的 Nodes，也就是 target 和 source 中的
+ */
+void OriginUtil::GetAllDirectNodes() {
+  queue<Node*> q;
+  for (auto node : input_target_) {
+    q.push(node);
+    direct_nodes_.push_back(node);
+  }
+
+  while (!q.empty()) {
+    Node* node = q.front();
+    q.pop();
+    
+    vector<Node*> output_nodes;
+    GetOutputNodeByNode(node, &output_nodes);
+    for (auto node : output_nodes) {
+      if (std::find(direct_nodes_.begin(), direct_nodes_.end(), node) == direct_nodes_.end()) {
+        q.push(node);
+        direct_nodes_.push_back(node);
+      }
+    }
+  }
 }
 
 void OriginUtil::ReverseDijkstra() {
@@ -26,8 +53,9 @@ void OriginUtil::ReverseDijkstra() {
     // 获取当前节点所有输出后，更新 map 中的距离
     for (auto node : output_nodes) {
       auto iter = reverse_djk_m.find(node);
-      if (iter != reverse_djk_m.end() && iter->second < dist + 1)
+      if (iter != reverse_djk_m.end() && iter->second < dist + 1) {
         iter->second = dist + 1;
+      }
 
       else if (iter == reverse_djk_m.end()) {
         // 说明可以入 queue，因为 map 还没有记录过，说明是新节点

--- a/src/origin_util.h
+++ b/src/origin_util.h
@@ -13,21 +13,17 @@ struct Edge;
 struct State;
 
 struct OriginUtil {
-  OriginUtil(vector<Node*> input_target, State* state,
-             DiskInterface* disk_interface)
-      : state_(state),
-        disk_interface_(disk_interface),
-        input_target_(input_target),
-        dyndep_loader_(state, disk_interface) {}
+  OriginUtil(vector<Node*> input_target)
+      : input_target_(input_target) {}
   
-  State* state_;
-  DiskInterface* disk_interface_;
-  DyndepLoader dyndep_loader_;
   set<Node*> visited_nodes_;
   EdgeSet visited_edges_;
 
   vector<Node*> input_target_;
-  int GetAllImpactNode(vector<Node*> input_nodes);
+  int GetAllImpactNode();
+
+  vector<Node*> direct_nodes_;
+  void GetAllDirectNodes();
 
   vector<pair<Node*, size_t>> nodes_dist;
   void ReverseDijkstra();
@@ -60,6 +56,16 @@ private:
                             edge_outputs.begin(), edge_outputs.end());
     }
     return;
+  }
+
+  bool AllInputNodesReady(Node* node) {
+    // 不在 visited_nodes_ 中就说明还没 ready
+    for (auto input : node->in_edge()->inputs_) {
+      if (visited_nodes_.find(input) != visited_nodes_.end()) {
+        return false;
+      }
+    }
+    return true;
   }
 };
 


### PR DESCRIPTION
目前出现 target dist 比 source dist 还要小的情况。这是因为 target dist 被赋值之后，source dist 又再次刷新，但 target dist 无法同步更新

现在计划使用拓扑排序